### PR TITLE
Plugin rebranded

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   </a>
 
   <p align="center">
-    Your next lobby system
+    Your NxT minecraft ecosystem
     <br />
     <a href="https://github.com/NxTCrew/NxTBase/wiki"><strong>Explore the docs »</strong></a>
     <br />
@@ -43,7 +43,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-NxT is a entire ecosystem of extensions for Minecraft network. This is the base plugin of the ecosystem, which can load extensions and provide a base for them.
+NxT is a entire ecosystem of extensions for Minecraft networks. This is the base plugin of the ecosystem, which can load extensions and provide a base for them.
 You, as a User, can simple choose from a variety of extensions and install them to your server. You can also create your own extensions and share them with the community.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "nxt"
-version = "0.0.5"
+version = "0.1.0"
 
 repositories {
     maven("https://repo.flawcra.cc/mirrors")
@@ -65,7 +65,7 @@ tasks {
     withType<ShadowJar> {
         mergeServiceFiles()
         configurations = listOf(project.configurations.shadow.get())
-        archiveFileName.set("NxTLobby.jar")
+        archiveFileName.set("NxT.jar")
     }
 }
 

--- a/src/main/kotlin/nxt/base/extensions/ExtensionsManager.kt
+++ b/src/main/kotlin/nxt/base/extensions/ExtensionsManager.kt
@@ -1,4 +1,4 @@
-package nxt.lobby.extensions
+package nxt.base.extensions
 
 import com.google.gson.Gson
 import com.google.gson.JsonElement
@@ -7,8 +7,8 @@ import de.fruxz.ascend.json.fromJsonStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import nxt.lobby.extensions.types.ExtensionInfo
-import nxt.lobby.extensions.types.NxTExtension
+import nxt.base.extensions.types.ExtensionInfo
+import nxt.base.extensions.types.NxTExtension
 import org.bukkit.plugin.Plugin
 import java.io.File
 import java.io.FileOutputStream

--- a/src/main/kotlin/nxt/base/extensions/types/ExtensionInfo.kt
+++ b/src/main/kotlin/nxt/base/extensions/types/ExtensionInfo.kt
@@ -1,4 +1,4 @@
-package nxt.lobby.extensions.types
+package nxt.base.extensions.types
 
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/nxt/base/extensions/types/NxTExtension.kt
+++ b/src/main/kotlin/nxt/base/extensions/types/NxTExtension.kt
@@ -1,4 +1,4 @@
-package nxt.lobby.extensions.types
+package nxt.base.extensions.types
 
 import org.bukkit.plugin.Plugin
 import java.io.File

--- a/src/main/kotlin/nxt/spigot/NxTSpigot.kt
+++ b/src/main/kotlin/nxt/spigot/NxTSpigot.kt
@@ -1,9 +1,9 @@
-package nxt.lobby
+package nxt.spigot
 
-import nxt.lobby.extensions.ExtensionsManager
+import nxt.base.extensions.ExtensionsManager
 import org.bukkit.plugin.java.JavaPlugin
 
-class NxTLobby : JavaPlugin() {
+class NxTSpigot : JavaPlugin() {
 
     lateinit var extensionsManager: ExtensionsManager
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
-name: NxTLobby
-main: nxt.lobby.NxTLobby
+name: NxT
+main: nxt.spigot.NxTSpigot
+description: NxT is a entire ecosystem of extensions for Minecraft networks.
 version: "${project.version}"
 api-version: 1.19
 author: NxT


### PR DESCRIPTION
- Package name change (breaking)
- Renamed the plugin to NxT
- Renamed the JavaPlugin NxTLobby class to NxTSpigot as this is the entry point for the spigot version
- Changed name, description and main in the plugin.yml
- Updated api version to 0.1.0